### PR TITLE
feat: reject empty/whitespace input in Serialization.FromJson (Bureau .NET proof)

### DIFF
--- a/bureau.buildconfig.json
+++ b/bureau.buildconfig.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "language": "dotnet",
+  "languageVersion": "8.0",
+  "toolchain": "dotnet",
+  "install": "dotnet restore src/AnotherJsonLib.sln",
+  "build": "dotnet build src/AnotherJsonLib.sln -c Release --no-restore",
+  "test": "dotnet test src/AnotherJsonLib.sln -c Release --no-restore"
+}

--- a/src/AnotherJsonLib/Utility/Serialization.cs
+++ b/src/AnotherJsonLib/Utility/Serialization.cs
@@ -113,9 +113,9 @@ public static class Serialization
     
     private static T? DeserializeWithExceptionHandling<T>(string json, JsonSerializerOptions options)
     {
+        ExceptionHelpers.ThrowIfNullOrWhiteSpace(json, nameof(json));
         return ExceptionHelpers.SafeExecuteWithDefault(() =>
             {
-                ExceptionHelpers.ThrowIfNull(json, nameof(json));
                 return JsonSerializer.Deserialize<T>(json, options);
             },
             default,
@@ -133,6 +133,11 @@ public static class Serialization
     /// <returns>True if deserialization was successful; otherwise, false.</returns>
     public static bool TryFromJson<T>(this string json, out T? result, JsonSerializerOptions? options = null, bool useDiagnosticTracker = false)
     {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            result = default;
+            return false;
+        }
         result = FromJson<T>(json, options, useDiagnosticTracker);
         return result != null;
     }

--- a/tests/AnotherJsonLib.Tests/LibTests/SerializationTests.cs
+++ b/tests/AnotherJsonLib.Tests/LibTests/SerializationTests.cs
@@ -1,0 +1,67 @@
+using AnotherJsonLib.Exceptions;
+using AnotherJsonLib.Utility;
+using Shouldly;
+
+namespace AnotherJsonLib.Tests.LibTests;
+
+public class SerializationTests
+{
+    private class TestObject
+    {
+        public string Name { get; set; } = string.Empty;
+        public int Value { get; set; }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FromJson_WithEmptyOrWhitespace_ThrowsJsonArgumentException(string input)
+    {
+        // Act & Assert
+        Should.Throw<JsonArgumentException>(() => input.FromJson<TestObject>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryFromJson_WithEmptyOrWhitespace_ReturnsFalse(string input)
+    {
+        // Act
+        bool success = input.TryFromJson<TestObject>(out var result);
+
+        // Assert
+        success.ShouldBeFalse();
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FromJson_WithValidJson_DeserializesCorrectly()
+    {
+        // Arrange
+        string json = "{\"Name\":\"Test\",\"Value\":42}";
+
+        // Act
+        var result = json.FromJson<TestObject>();
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe("Test");
+        result.Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public void TryFromJson_WithValidJson_ReturnsTrueAndDeserializes()
+    {
+        // Arrange
+        string json = "{\"Name\":\"Test\",\"Value\":42}";
+
+        // Act
+        bool success = json.TryFromJson<TestObject>(out var result);
+
+        // Assert
+        success.ShouldBeTrue();
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe("Test");
+        result.Value.ShouldBe(42);
+    }
+}


### PR DESCRIPTION
Built autonomously by **The Bureau** (language-agnostic .NET worker, the-bureau #226 Phase 5) and validated on the live k3s cluster; promoted to \`dogfood\`, now up for human review → \`main\`.

## What changed (additive, idiomatic)
- **`src/AnotherJsonLib/Utility/Serialization.cs`** — `FromJson<T>` / `TryFromJson<T>` now reject empty-or-whitespace `json` early via the library's own `ExceptionHelpers.ThrowIfNullOrWhiteSpace`, throwing `JsonArgumentException` (FromJson) / returning `false` (TryFromJson) instead of surfacing a confusing low-level `JsonException` deep in parsing. Previously only `null` was guarded.
- **`tests/AnotherJsonLib.Tests/LibTests/SerializationTests.cs`** — focused xUnit tests: empty + whitespace → `JsonArgumentException`; `TryFromJson` → `false` for both; valid JSON still deserializes (no regression).
- **`bureau.buildconfig.json`** — The Bureau toolchain descriptor (dotnet/xUnit); harmless to your own tooling.

## Validation
Full suite **514 passed, 0 failed** (508 → 514, +6 new), run token-free by a mechanical `dotnet restore && dotnet test` pod on the merged integration ref — no agent, no model tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)